### PR TITLE
Bump dropwizard metrics to 4.1.12.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
         <kiwi.version>0.12.0</kiwi.version>
 
         <!-- Versions for provided dependencies -->
-        <dropwizard.metrics.version>4.1.11</dropwizard.metrics.version>
+        <dropwizard.metrics.version>4.1.12.1</dropwizard.metrics.version>
 
         <!-- Versions for optional dependencies -->
         <jsr305.version>3.0.2</jsr305.version>


### PR DESCRIPTION
Maybe we need to add this to the list of dependabot dependencies since it usually gets bumped with dropwizard updates, but we don't use dropwizard directly here?