### PR TITLE
Add HealthStatus Comparator to compare by severity

### DIFF
--- a/src/main/java/org/kiwiproject/metrics/health/HealthStatus.java
+++ b/src/main/java/org/kiwiproject/metrics/health/HealthStatus.java
@@ -9,12 +9,15 @@ import static org.kiwiproject.collect.KiwiMaps.isNullOrEmpty;
 import static org.kiwiproject.metrics.health.HealthCheckResults.SEVERITY_DETAIL;
 
 import com.google.common.collect.Iterables;
+import lombok.AccessLevel;
+import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.BooleanUtils;
 
 import javax.annotation.Nullable;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.Map;
 import java.util.Optional;
 
@@ -65,6 +68,7 @@ public enum HealthStatus {
     /**
      * Internal value used to compare severity (we do NOT want to rely on the ordinal of the enum constants).
      */
+    @Getter(AccessLevel.PACKAGE)
     private final int value;
 
     HealthStatus(int value) {
@@ -234,6 +238,10 @@ public enum HealthStatus {
         return compare(status1, status2) > 0 ? status1 : status2;
     }
 
+    private static int compare(HealthStatus status1, HealthStatus status2) {
+        return comparingSeverity().compare(status1, status2);
+    }
+
     /**
      * Return the highest severity in the (non-null, non-empty) collection of status values.
      *
@@ -244,10 +252,15 @@ public enum HealthStatus {
     public static HealthStatus highestSeverity(Collection<HealthStatus> statuses) {
         checkArgument(nonNull(statuses) && !statuses.isEmpty(), "statuses cannot be empty or null");
 
-        return Collections.max(statuses, HealthStatus::compare);
+        return Collections.max(statuses, comparingSeverity());
     }
 
-    private static int compare(HealthStatus status1, HealthStatus status2) {
-        return Integer.compare(status1.value, status2.value);
+    /**
+     * Return a {@link Comparator} that compares {@link HealthStatus} objects from lowest to highest severity.
+     *
+     * @return a comparator that orders from lowest to highest severity
+     */
+    public static Comparator<HealthStatus> comparingSeverity() {
+        return HealthStatusComparator.INSTANCE;
     }
 }

--- a/src/main/java/org/kiwiproject/metrics/health/HealthStatus.java
+++ b/src/main/java/org/kiwiproject/metrics/health/HealthStatus.java
@@ -24,6 +24,14 @@ import java.util.Optional;
 /**
  * This enum is used to indicate the health status/severity for both a service (i.e. multiple running instances)
  * as well as the status of individual service instances.
+ * <p>
+ * If you need to compare {@link HealthStatus} instances by severity, use {@link HealthStatus#comparingSeverity()}
+ * to obtain a {@link Comparator}.
+ *
+ * @implNote Even though the natural order of the constants is defined from lowest to highest severity, we don't
+ * encourage relying on this and instead encourage using {@link HealthStatus#comparingSeverity()} to obtain a
+ * Comparator. For example, even though no changes are anticipated, it is possible a new constant could be added
+ * that falls between existing values, and could break existing assumptions.
  */
 @Slf4j
 public enum HealthStatus {

--- a/src/main/java/org/kiwiproject/metrics/health/HealthStatusComparator.java
+++ b/src/main/java/org/kiwiproject/metrics/health/HealthStatusComparator.java
@@ -1,0 +1,16 @@
+package org.kiwiproject.metrics.health;
+
+import java.util.Comparator;
+
+/**
+ * A Comparator that compares {@link HealthStatus} objects by severity.
+ */
+class HealthStatusComparator implements Comparator<HealthStatus> {
+
+    static final HealthStatusComparator INSTANCE = new HealthStatusComparator();
+
+    @Override
+    public int compare(HealthStatus status1, HealthStatus status2) {
+        return Comparator.comparingInt(HealthStatus::getValue).compare(status1, status2);
+    }
+}


### PR DESCRIPTION
* Add package-private HealthStatusComparator, which is a Comparator
  that compares HealthStatus objects by severity
* Add package-private getter method to HealthStatus#value for
  HealthStatusComparator to make use of
* Add static HealthStatus#comparingSeverity() method for easily getting
  an instance of HealthStatusComparator (which in this implementation
  is a singleton instance defined in HealthStatusComparator)

Closes #44