### PR TITLE
Bump kiwi, kiwi-test, and metrics versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,8 +28,8 @@
 
     <properties>
         <!-- Versions for required dependencies -->
-        <dropwizard.metrics.version>4.1.19</dropwizard.metrics.version>
-        <kiwi.version>0.22.0</kiwi.version>
+        <dropwizard.metrics.version>4.1.22</dropwizard.metrics.version>
+        <kiwi.version>0.23.0</kiwi.version>
 
         <!-- Versions for provided dependencies -->
 
@@ -37,7 +37,7 @@
         <jsr305.version>3.0.2</jsr305.version>
 
         <!-- Versions for test dependencies -->
-        <kiwi.test.version>0.18.0</kiwi.test.version>
+        <kiwi.test.version>0.19.0</kiwi.test.version>
 
         <!-- Sonar properties -->
         <sonar.projectKey>kiwiproject_metrics-healthchecks-severity</sonar.projectKey>


### PR DESCRIPTION
* Bump metrics-core from 4.1.19 to 4.1.22
* Bump metrics-healthchecks from 4.1.19 to 4.1.22
* Bump kiwi from 0.22.0 to 0.23.0
* Bump kiwi-test from 0.18.0 to 0.19.0