### PR TITLE
Bump dropwizard.metrics.version from 4.1.23 to 4.1.25

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
 
     <properties>
         <!-- Versions for required dependencies -->
-        <dropwizard.metrics.version>4.1.23</dropwizard.metrics.version>
+        <dropwizard.metrics.version>4.1.25</dropwizard.metrics.version>
         <kiwi.version>0.25.0</kiwi.version>
 
         <!-- Versions for provided dependencies -->


### PR DESCRIPTION
This matches the version that Dropwizard 2.0.24 is using.