### PR TITLE
Update parent POM and BOM for JDK 17 and major library updates

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java_version: [ '11', '17', '20' ]
+        java_version: [ '17', '20' ]
     steps:
       # Check out the project
       - uses: actions/checkout@v3
@@ -33,7 +33,7 @@ jobs:
       # Cache all the things
       - name: Cache SonarCloud packages
         uses: actions/cache@v3
-        if: ${{ env.SONAR_TOKEN != null && env.SONAR_TOKEN != '' && matrix.java_version == '11' }}
+        if: ${{ env.SONAR_TOKEN != null && env.SONAR_TOKEN != '' && matrix.java_version == '17' }}
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         with:
@@ -54,16 +54,16 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
         run: mvn -B -V compile
 
-      # Run tests when Java version > 11 (Sonar runs tests and analysis on JDK 11)
+      # Run tests when Java version > 17 (Sonar runs tests and analysis on JDK 17)
       - name: Run tests
-        if: ${{ matrix.java_version != '11' }}
+        if: ${{ matrix.java_version != '17' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
         run: mvn -B -V verify
 
-      # Run Sonar Analysis (on Java version 11 only)
+      # Run Sonar Analysis (on Java version 17 only)
       - name: Analyze with SonarCloud
-        if: ${{ env.SONAR_TOKEN != null && env.SONAR_TOKEN != '' && matrix.java_version == '11' }}
+        if: ${{ env.SONAR_TOKEN != null && env.SONAR_TOKEN != '' && matrix.java_version == '17' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -33,6 +33,12 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v3
 
+    - name: Set up Java 17
+      uses: actions/setup-java@v3
+      with:
+        distribution: temurin
+        java-version: 17
+
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v2
       with:

--- a/pom.xml
+++ b/pom.xml
@@ -5,11 +5,11 @@
     <parent>
         <groupId>org.kiwiproject</groupId>
         <artifactId>kiwi-parent</artifactId>
-        <version>2.0.20</version>
+        <version>3.0.1</version>
     </parent>
 
     <artifactId>metrics-healthchecks-severity</artifactId>
-    <version>1.0.14-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>${project.groupId}:${project.artifactId}</name>
@@ -28,11 +28,11 @@
 
     <properties>
         <!-- Versions for required dependencies -->
-        <kiwi.version>2.7.0</kiwi.version>
-        <kiwi-bom.version>1.1.1</kiwi-bom.version>
+        <kiwi.version>3.0.0</kiwi.version>
+        <kiwi-bom.version>2.0.0</kiwi-bom.version>
 
         <!-- Versions for test dependencies -->
-        <kiwi-test.version>2.4.0</kiwi-test.version>
+        <kiwi-test.version>3.0.0</kiwi-test.version>
 
         <!-- Sonar properties -->
         <sonar.projectKey>kiwiproject_metrics-healthchecks-severity</sonar.projectKey>

--- a/src/main/java/org/kiwiproject/metrics/health/HealthStatus.java
+++ b/src/main/java/org/kiwiproject/metrics/health/HealthStatus.java
@@ -23,7 +23,7 @@ import java.util.Optional;
 
 /**
  * This enum is used to indicate the health status/severity for both a service (i.e. multiple running instances)
- * as well as the status of individual service instances.
+ * and the status of individual service instances.
  * <p>
  * If you need to compare {@link HealthStatus} instances by severity, use {@link HealthStatus#comparingSeverity()}
  * to obtain a {@link Comparator}.
@@ -236,7 +236,7 @@ public enum HealthStatus {
      *
      * @param status1 the first status
      * @param status2 the second status
-     * @return the higher of the statuses
+     * @return the highest of the statuses
      * @throws IllegalArgumentException if either argument is null
      */
     public static HealthStatus max(HealthStatus status1, HealthStatus status2) {

--- a/src/test/java/org/kiwiproject/metrics/health/HealthStatusTest.java
+++ b/src/test/java/org/kiwiproject/metrics/health/HealthStatusTest.java
@@ -1,12 +1,9 @@
 package org.kiwiproject.metrics.health;
 
-import static java.util.stream.Collectors.toUnmodifiableList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.util.Lists.newArrayList;
 
-import lombok.Builder;
-import lombok.Value;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -364,7 +361,7 @@ class HealthStatusTest {
             var statuses = Arrays.stream(statusCsv.split(","))
                     .map(String::trim)
                     .map(HealthStatus::valueOf)
-                    .collect(toUnmodifiableList());
+                    .toList();
 
             assertThat(HealthStatus.highestSeverity(statuses)).isEqualTo(expectedHighest);
         }
@@ -456,14 +453,14 @@ class HealthStatusTest {
             Collections.shuffle(errors);
 
             var min = errors.stream()
-                    .map(WorkflowError::getHealthStatus)
+                    .map(WorkflowError::healthStatus)
                     .min(HealthStatus.comparingSeverity())
                     .orElseThrow();
 
             assertThat(min).isEqualTo(expectedMin);
 
             var max = errors.stream()
-                    .map(WorkflowError::getHealthStatus)
+                    .map(WorkflowError::healthStatus)
                     .max(HealthStatus.comparingSeverity())
                     .orElseThrow();
 
@@ -487,10 +484,6 @@ class HealthStatusTest {
         );
     }
 
-    @Value
-    @Builder
-    static class WorkflowError {
-        String message;
-        HealthStatus healthStatus;
+    record WorkflowError(String message, HealthStatus healthStatus) {
     }
 }


### PR DESCRIPTION
* Bump version to 2.0.0-SNAPSHOT
* Bump kiwi-parent from 2.0.20 to 3.0.1
* Bump kiwi-bom from 1.1.1 to 2.0.0
* Bump kiwi libraries to next major version
* Update build for JDK 17 and 20
* Update CodeQL workflow to use JDK 17
* Fix Dropwizard package changes
* Refactor from javax to jakarta namespace for Jakarta EE 9
* Misc changes: grammar fixes, JDK 17 cleanup