### PR TITLE
Allow severity health check details in HealthStatus#from factory method

### DIFF
--- a/src/main/java/org/kiwiproject/metrics/health/HealthStatus.java
+++ b/src/main/java/org/kiwiproject/metrics/health/HealthStatus.java
@@ -161,7 +161,11 @@ public enum HealthStatus {
             return severity;
         }
 
-        LOG.warn("Something gave us a severity that was not a String: {}", severityObj);
+        if (severityObj instanceof HealthStatus severity) {
+            return severity.name();
+        }
+
+        LOG.warn("Something gave us a severity that was not a String or HealthStatus: {}", severityObj);
         return null;
     }
 

--- a/src/test/java/org/kiwiproject/metrics/health/HealthStatusTest.java
+++ b/src/test/java/org/kiwiproject/metrics/health/HealthStatusTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.NullAndEmptySource;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -57,6 +58,21 @@ class HealthStatusTest {
                 );
 
                 assertThat(HealthStatus.from(healthDetails)).isEqualTo(HealthStatus.WARN);
+            }
+
+            @ParameterizedTest
+            @EnumSource(HealthStatus.class)
+            void shouldAcceptHealthSeverityObject(HealthStatus status) {
+                var healthy = switch (status) {
+                    case OK, INFO -> true;
+                    case WARN, CRITICAL, FATAL -> false;
+                };
+
+                Map<String, Object> healthDetails = Map.of(
+                        "database", Map.of("healthy", healthy, "severity", status)
+                );
+
+                assertThat(HealthStatus.from(healthDetails)).isEqualTo(status);
             }
         }
     }


### PR DESCRIPTION
* In the HealthStatus#from method that accepts a Map of healthDetails, the "severity" details can now be either String or HealthStatus.

Closes #274