### PR TITLE
Update test checking null severity

### DIFF
--- a/src/test/java/org/kiwiproject/metrics/health/HealthStatusTest.java
+++ b/src/test/java/org/kiwiproject/metrics/health/HealthStatusTest.java
@@ -146,10 +146,11 @@ class HealthStatusTest {
             assertThat(HealthStatus.from(healthDetails)).isEqualTo(HealthStatus.WARN);
         }
 
-        @Test
-        void shouldBe_WARN_WhenGiven_MapWithNullSeverity() {
+        @ParameterizedTest
+        @ValueSource(booleans = {true, false})
+        void shouldBe_WARN_WhenGiven_MapWithHealthyOrUnhealthyAnd_NullSeverity(boolean isHealthy) {
             Map<String, Object> healthDetails = Map.of(
-                    "database", KiwiMaps.newHashMap("healthy", false, "severity", null)
+                    "database", KiwiMaps.newHashMap("healthy", isHealthy, "severity", null)
             );
 
             assertThat(HealthStatus.from(healthDetails)).isEqualTo(HealthStatus.WARN);


### PR DESCRIPTION
The new test in HealthStatusTest that checks that the HealthStatus is WARN when given a null severity should test when "healthy" is true or false. We want the returned HealthStatus to be WARN anytime we find a "severity" detail with a null value, since it indicates a problem somewhere else, i.e., in the health check that set the null severity detail.